### PR TITLE
Fix tetra volumes

### DIFF
--- a/src/meshzoo/_ball.py
+++ b/src/meshzoo/_ball.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from ._cube import cube_hexa, cube_tetra
+from ._helpers import _cell_volumes_tetra
 
 
 def ball_hexa(n: int):
@@ -29,5 +30,9 @@ def ball_tetra(n: int):
     beta = np.linalg.norm(nodes, axis=1)
     idx = beta > 1.0e-13
     nodes[idx] = (nodes[idx].T * (alpha[idx] / beta[idx])).T
+
+    # fix elems with negative volumes
+    volumes = _cell_volumes_tetra(nodes, elems)
+    elems[volumes < 0] = elems[volumes < 0][:, [0, 2, 1, 3]]
 
     return nodes, elems

--- a/src/meshzoo/_cube.py
+++ b/src/meshzoo/_cube.py
@@ -2,6 +2,8 @@ from typing import Tuple, Union
 
 import numpy as np
 
+from ._helpers import _cell_volumes_tetra
+
 
 # backwards compatibility
 def cube(
@@ -364,5 +366,9 @@ def cube_tetra(
             elems4.reshape(-1, 4),
         ]
     )
+
+    # fix elems with negative volumes
+    volumes = _cell_volumes_tetra(nodes, elems)
+    elems[volumes < 0] = elems[volumes < 0][:, [0, 2, 1, 3]]
 
     return nodes, elems

--- a/src/meshzoo/_helpers.py
+++ b/src/meshzoo/_helpers.py
@@ -279,3 +279,21 @@ def insert_midpoints_edges(points, cells, cell_type):
     cells_new = np.hstack((cells, cells_edges))
 
     return points_new, cells_new
+
+
+def _cell_volumes_tetra(points, cells):
+    "Calculate cell volumes of tetrahedrons."
+
+    # extract point no. 0 of all cells and reshape
+    p0 = points[cells][:, 0].reshape(len(cells), 1, 3)
+
+    # calculate edge vectors "i" as v[:, i] for all cells
+    edges = (points[cells] - np.repeat(p0, 4, axis=1))[:, 1:]
+
+    # evaluate cell volumes by the triple product
+    # cyclic permutations lead to identical results (0,1,2), (1,2,0), (2,0,1)
+    cell_volumes = (
+        np.einsum("...i,...i->...", edges[:, 0], np.cross(edges[:, 1], edges[:, 2])) / 6
+    )
+
+    return cell_volumes

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,3 +8,21 @@ def _near_equal(a, b, tol=1.0e-12):
 def _get_signed_areas(coords, cells):
     bc = coords[:, cells]
     return np.cross((bc[:, :, 1] - bc[:, :, 0]).T, (bc[:, :, 2] - bc[:, :, 0]).T)
+
+
+def _get_signed_volumes_tetra(points, cells):
+    "Calculate cell volumes of tetrahedrons."
+
+    # extract point no. 0 of all cells and reshape
+    p0 = points[cells][:, 0].reshape(len(cells), 1, 3)
+
+    # calculate edge vectors "i" as v[:, i] for all cells
+    edges = (points[cells] - np.repeat(p0, 4, axis=1))[:, 1:]
+
+    # evaluate cell volumes by the triple product
+    # cyclic permutations lead to identical results (0,1,2), (1,2,0), (2,0,1)
+    cell_volumes = (
+        np.einsum("...i,...i->...", edges[:, 0], np.cross(edges[:, 1], edges[:, 2])) / 6
+    )
+
+    return cell_volumes

--- a/tests/test_ball.py
+++ b/tests/test_ball.py
@@ -1,3 +1,6 @@
+import numpy as np
+from helpers import _get_signed_volumes_tetra
+
 import meshzoo
 
 
@@ -15,3 +18,12 @@ def test_ball_tetra():
     # meshio.Mesh(points, {"tetra": cells}).write("ball-tetra.vtk")
     assert len(points) == 1331
     assert len(cells) == 5000
+
+    volumes = _get_signed_volumes_tetra(points, cells)
+
+    assert len(volumes) == len(cells)
+    assert np.all(np.sign(volumes) == 1)
+
+
+if __name__ == "__main__":
+    test_ball_tetra()

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -1,4 +1,5 @@
 import numpy as np
+from helpers import _get_signed_volumes_tetra
 
 import meshzoo
 
@@ -13,6 +14,11 @@ def test_cube():
     assert all(np.sum(points, axis=0) == [13.5, 13.5, 13.5])
     assert len(cells) == 40
 
+    volumes = _get_signed_volumes_tetra(points, cells)
+
+    assert len(volumes) == len(cells)
+    assert np.all(np.sign(volumes) == 1)
+
 
 def test_cube_hexa():
     points, cells = meshzoo.cube_hexa((0.0, 0.0, 0.0), (1.0, 1.0, 1.0), 11)
@@ -25,3 +31,7 @@ def test_cube_hexa():
     assert len(points) == 27
     assert all(np.sum(points, axis=0) == [13.5, 13.5, 13.5])
     assert len(cells) == 8
+
+
+if __name__ == "__main__":
+    test_cube()


### PR DESCRIPTION
If the cell volumes of tet meshes (cube and ball) are calculated by the triple product of edge vectors (see https://en.wikipedia.org/wiki/Tetrahedron#Volume) it seems that the cell connectivity of meshzoo leads to some negative cell volumes.

A swap of two colums in the cell connectivity fixes this misorientation.

For discussion and code snippet see issue #68.

